### PR TITLE
.nimble: add test task

### DIFF
--- a/RingBuffer.nimble
+++ b/RingBuffer.nimble
@@ -1,9 +1,12 @@
-[Package]
-name          = "RingBuffer"
+# Package
 version       = "0.1.2"
 author        = "Graeme Yeates"
 description   = "Circular buffer implementation"
 license       = "MIT"
 
-[Deps]
-Requires: "nim >= 0.10.0"
+# Dependencies
+requires "nim >= 0.10.0"
+
+# Tasks
+task test, "Runs the test suite":
+  exec "nim c -r -f test/buffer.nim"


### PR DESCRIPTION
This adds the task `test` to the .nimble file, so tests can easily be run with `nimble test`.