### PR TITLE
add `remove()`, which allows using the buffer like a queue

### DIFF
--- a/RingBuffer.nim
+++ b/RingBuffer.nim
@@ -84,8 +84,14 @@ proc add*[T](b: var RingBuffer[T], data: openArray[T]) =
   b.size = min(b.size + len(data), b.length)
   adjustHead(b)
 
+proc remove*[T](b: var RingBuffer[T]): T =
+  ## Remove the oldest element from the buffer and return it
+  result = b.data[b.head] # Note: will throw error if oob
+  b.size -= 1
+  adjustHead(b)
+
 proc pop*[T](b: var RingBuffer[T]): T =
-  ## Remove an element from the buffer and return it
+  ## Remove the youngest element from the buffer and return it
   result = b.data[b.tail] # Note: will throw error if oob
   adjustTail(b, -1)
   b.size -= 1

--- a/test/buffer.nim
+++ b/test/buffer.nim
@@ -60,12 +60,19 @@ suite "Adding":
     let s = buffer.slice(0, 2)
     check s == @[6, 7]
 
+  test "Removing":
+    let r = buffer.remove()
+    check r == 6
+    check buffer.len == 2
+    let s = @buffer
+    check s == @[7, 8]
+
   test "Popping":
     let r = buffer.pop()
     check r == 8
-    check buffer.len == 2
+    check buffer.len == 1
     let s = @buffer
-    check s == @[6, 7]
+    check s == @[7]
 
   test "Empty":
     buffer.empty


### PR DESCRIPTION
It caused some confusion for me that `pop()` makes the buffer behave like a stack and that, apparently, there is no interface to use it as a queue – am I wrong?

This PR adds `remove()` which removes and returns the oldest element from the buffer, incl. (inline) documentation update and a test.